### PR TITLE
Adding schemamap to linter

### DIFF
--- a/helper/terraformtype/terraformtype.go
+++ b/helper/terraformtype/terraformtype.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// IsTypeHelperSchema returns if the type is a schema from the terraform helper package
 func IsTypeHelperSchema(t types.Type) bool {
 	switch t := t.(type) {
 	default:

--- a/helper/terraformtype/terraformtype.go
+++ b/helper/terraformtype/terraformtype.go
@@ -1,0 +1,22 @@
+package terraformtype
+
+import (
+	"go/types"
+	"strings"
+)
+
+func IsTypeHelperSchema(t types.Type) bool {
+	switch t := t.(type) {
+	default:
+		return false
+	case *types.Named:
+		if t.Obj().Name() != "Schema" {
+			return false
+		}
+		// HasSuffix here due to vendoring
+		if !strings.HasSuffix(t.Obj().Pkg().Path(), "github.com/hashicorp/terraform/helper/schema") {
+			return false
+		}
+	}
+	return true
+}

--- a/passes/S001/S001.go
+++ b/passes/S001/S001.go
@@ -81,11 +81,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if typeListOrSet && !elemFound {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
 			}
 		}
 	}

--- a/passes/S001/S001.go
+++ b/passes/S001/S001.go
@@ -81,7 +81,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if typeListOrSet && !elemFound {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeList or TypeSet should include Elem", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S001/testdata/src/a/alias.go
+++ b/passes/S001/testdata/src/a/alias.go
@@ -12,4 +12,16 @@ func falias() {
 	_ = s.Schema{ // want "schema of TypeList or TypeSet should include Elem"
 		Type: s.TypeSet,
 	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema of TypeList or TypeSet should include Elem"
+			Type: s.TypeList,
+		},
+	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema of TypeList or TypeSet should include Elem"
+			Type: s.TypeSet,
+		},
+	}
 }

--- a/passes/S001/testdata/src/a/main.go
+++ b/passes/S001/testdata/src/a/main.go
@@ -22,4 +22,10 @@ func f() {
 		Type: schema.TypeSet,
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema of TypeList or TypeSet should include Elem"
+			Type:     schema.TypeList,
+		},
+	}
 }

--- a/passes/S001/testdata/src/a/outside_package.go
+++ b/passes/S001/testdata/src/a/outside_package.go
@@ -12,4 +12,16 @@ func foutside() {
 	_ = schema.Schema{
 		Type: schema.TypeSet,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Type: schema.TypeList,
+		},
+	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Type: schema.TypeSet,
+		},
+	}
 }

--- a/passes/S002/S002.go
+++ b/passes/S002/S002.go
@@ -70,11 +70,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if optionalEnabled && requiredEnabled {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and Optional", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Optional", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema should not enable Required and Optional", analyzerName)
 			}
 		}
 	}

--- a/passes/S002/S002.go
+++ b/passes/S002/S002.go
@@ -70,7 +70,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if optionalEnabled && requiredEnabled {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Optional", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and Optional", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Optional", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S002/testdata/src/a/alias.go
+++ b/passes/S002/testdata/src/a/alias.go
@@ -9,4 +9,11 @@ func falias() {
 		Required: true,
 		Optional: true,
 	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema should not enable Required and Optional"
+			Required: true,
+			Optional: true,
+		},
+	}
 }

--- a/passes/S002/testdata/src/a/main.go
+++ b/passes/S002/testdata/src/a/main.go
@@ -17,4 +17,11 @@ func f() {
 	_ = schema.Schema{
 		Optional: true,
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema should not enable Required and Optional"
+			Required: true,
+			Optional: true,
+		},
+	}
 }

--- a/passes/S002/testdata/src/a/outside_package.go
+++ b/passes/S002/testdata/src/a/outside_package.go
@@ -9,4 +9,11 @@ func foutside() {
 		Required: true,
 		Optional: true,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Required: true,
+			Optional: true,
+		},
+	}
 }

--- a/passes/S003/S003.go
+++ b/passes/S003/S003.go
@@ -70,11 +70,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if computedEnabled && requiredEnabled {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and Computed", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Computed", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema should not enable Required and Computed", analyzerName)
 			}
 		}
 	}

--- a/passes/S003/S003.go
+++ b/passes/S003/S003.go
@@ -70,7 +70,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if computedEnabled && requiredEnabled {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Computed", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and Computed", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and Computed", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S003/testdata/src/a/alias.go
+++ b/passes/S003/testdata/src/a/alias.go
@@ -9,4 +9,11 @@ func falias() {
 		Required: true,
 		Computed: true,
 	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema should not enable Required and Computed"
+			Required: true,
+			Computed: true,
+		},
+	}
 }

--- a/passes/S003/testdata/src/a/main.go
+++ b/passes/S003/testdata/src/a/main.go
@@ -17,4 +17,11 @@ func f() {
 	_ = schema.Schema{
 		Computed: true,
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema should not enable Required and Computed"
+			Required: true,
+			Computed: true,
+		},
+	}
 }

--- a/passes/S003/testdata/src/a/outside_package.go
+++ b/passes/S003/testdata/src/a/outside_package.go
@@ -9,4 +9,11 @@ func foutside() {
 		Required: true,
 		Computed: true,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Required: true,
+			Computed: true,
+		},
+	}
 }

--- a/passes/S004/S004.go
+++ b/passes/S004/S004.go
@@ -74,7 +74,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if defaultConfigured && requiredEnabled {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and configure Default", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and configure Default", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and configure Default", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S004/S004.go
+++ b/passes/S004/S004.go
@@ -74,11 +74,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if defaultConfigured && requiredEnabled {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema should not enable Required and configure Default", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Required and configure Default", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema should not enable Required and configure Default", analyzerName)
 			}
 		}
 	}

--- a/passes/S004/testdata/src/a/alias.go
+++ b/passes/S004/testdata/src/a/alias.go
@@ -9,4 +9,11 @@ func falias() {
 		Required: true,
 		Default:  true,
 	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema should not enable Required and configure Default"
+			Required: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S004/testdata/src/a/main.go
+++ b/passes/S004/testdata/src/a/main.go
@@ -22,4 +22,11 @@ func f() {
 	_ = schema.Schema{
 		Default: true,
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema should not enable Required and configure Default"
+			Required: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S004/testdata/src/a/outside_package.go
+++ b/passes/S004/testdata/src/a/outside_package.go
@@ -9,4 +9,11 @@ func foutside() {
 		Required: true,
 		Default:  true,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Required: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S005/S005.go
+++ b/passes/S005/S005.go
@@ -74,11 +74,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if computedEnabled && defaultConfigured {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema should not enable Computed and configure Default", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Computed and configure Default", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema should not enable Computed and configure Default", analyzerName)
 			}
 		}
 	}

--- a/passes/S005/S005.go
+++ b/passes/S005/S005.go
@@ -74,7 +74,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if computedEnabled && defaultConfigured {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Computed and configure Default", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema should not enable Computed and configure Default", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema should not enable Computed and configure Default", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S005/testdata/src/a/alias.go
+++ b/passes/S005/testdata/src/a/alias.go
@@ -9,4 +9,11 @@ func falias() {
 		Computed: true,
 		Default:  true,
 	}
+
+	_ = map[string]*s.Schema{
+		"name": { // want "schema should not enable Computed and configure Default"
+			Computed: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S005/testdata/src/a/main.go
+++ b/passes/S005/testdata/src/a/main.go
@@ -22,4 +22,11 @@ func f() {
 	_ = schema.Schema{
 		Default: true,
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema should not enable Computed and configure Default"
+			Computed: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S005/testdata/src/a/outside_package.go
+++ b/passes/S005/testdata/src/a/outside_package.go
@@ -9,4 +9,11 @@ func foutside() {
 		Computed: true,
 		Default:  true,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Computed: true,
+			Default:  true,
+		},
+	}
 }

--- a/passes/S006/S006.go
+++ b/passes/S006/S006.go
@@ -83,11 +83,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if typeMap && !elemFound {
-			switch schema.Type.(type) {
+			switch t := schema.Type.(type) {
 			default:
 				pass.Reportf(schema.Lbrace, "%s: schema of TypeMap should include Elem", analyzerName)
 			case *ast.SelectorExpr:
-				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeMap should include Elem", analyzerName)
+				pass.Reportf(t.Sel.Pos(), "%s: schema of TypeMap should include Elem", analyzerName)
 			}
 		}
 	}

--- a/passes/S006/S006.go
+++ b/passes/S006/S006.go
@@ -83,7 +83,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if typeMap && !elemFound {
-			pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeMap should include Elem", analyzerName)
+			switch schema.Type.(type) {
+			default:
+				pass.Reportf(schema.Lbrace, "%s: schema of TypeMap should include Elem", analyzerName)
+			case *ast.SelectorExpr:
+				pass.Reportf(schema.Type.(*ast.SelectorExpr).Sel.Pos(), "%s: schema of TypeMap should include Elem", analyzerName)
+			}
 		}
 	}
 

--- a/passes/S006/testdata/src/a/alias.go
+++ b/passes/S006/testdata/src/a/alias.go
@@ -1,7 +1,6 @@
 package a
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
 	s "github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -10,7 +9,7 @@ func falias() {
 		Type: s.TypeMap,
 	}
 
-	_ = map[string]*schema.Schema{
+	_ = map[string]*s.Schema{
 		"name": { // want "schema of TypeMap should include Elem"
 			Type: s.TypeMap,
 		},

--- a/passes/S006/testdata/src/a/alias.go
+++ b/passes/S006/testdata/src/a/alias.go
@@ -1,11 +1,18 @@
 package a
 
 import (
+	"github.com/hashicorp/terraform/helper/schema"
 	s "github.com/hashicorp/terraform/helper/schema"
 )
 
 func falias() {
 	_ = s.Schema{ // want "schema of TypeMap should include Elem"
 		Type: s.TypeMap,
+	}
+
+	_ = map[string]*schema.Schema{
+		"name": { // want "schema of TypeMap should include Elem"
+			Type: s.TypeMap,
+		},
 	}
 }

--- a/passes/S006/testdata/src/a/main.go
+++ b/passes/S006/testdata/src/a/main.go
@@ -13,4 +13,10 @@ func f() {
 		Type: schema.TypeMap,
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
+
+	_ = map[string]*schema.Schema{ 
+		"name": { // want "schema of TypeMap should include Elem"
+			Type: schema.TypeMap,
+		},
+	}
 }

--- a/passes/S006/testdata/src/a/outside_package.go
+++ b/passes/S006/testdata/src/a/outside_package.go
@@ -8,4 +8,10 @@ func foutside() {
 	_ = schema.Schema{
 		Type: schema.TypeMap,
 	}
+
+	_ = map[string]*schema.Schema{
+		"name": {
+			Type: schema.TypeMap,
+		},
+	}
 }

--- a/passes/schemamap/README.md
+++ b/passes/schemamap/README.md
@@ -1,0 +1,14 @@
+# passes/schemamap
+
+This pass only works with Terraform schema maps that are fully defined:
+
+```go
+Schema: map[string]*schema.Schema{
+    "attr": {
+        Type:         schema.TypeString,
+        Optional:     true,
+        Computed:     true,
+        ValidateFunc: /* ... */,
+    },
+},
+```

--- a/passes/schemamap/schemamap.go
+++ b/passes/schemamap/schemamap.go
@@ -31,7 +31,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
 		x := n.(*ast.CompositeLit)
 
-		if !IsSchemaMap(pass, x) {
+		if !isSchemaMap(pass, x) {
 			return
 		}
 
@@ -41,7 +41,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return result, nil
 }
 
-func IsSchemaMap(pass *analysis.Pass, cl *ast.CompositeLit) bool {
+func isSchemaMap(pass *analysis.Pass, cl *ast.CompositeLit) bool {
 	switch v := cl.Type.(type) {
 	default:
 		return false
@@ -65,7 +65,8 @@ func IsSchemaMap(pass *analysis.Pass, cl *ast.CompositeLit) bool {
 	return true
 }
 
-func SchemaAttributes(schemamap *ast.CompositeLit) []*ast.CompositeLit {
+// GetSchemaAttributes returns all attributes held in a map[string]*schema.Schema
+func GetSchemaAttributes(schemamap *ast.CompositeLit) []*ast.CompositeLit {
 	var result []*ast.CompositeLit
 
 	for _, elt := range schemamap.Elts {

--- a/passes/schemamap/schemamap.go
+++ b/passes/schemamap/schemamap.go
@@ -1,0 +1,81 @@
+package schemamap
+
+import (
+	"go/ast"
+	"reflect"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "schema",
+	Doc:  "find map[string]*schema.Schema literals for later passes",
+	Requires: []*analysis.Analyzer{
+		inspect.Analyzer,
+	},
+	Run:        run,
+	ResultType: reflect.TypeOf([]*ast.CompositeLit{}),
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.CompositeLit)(nil),
+	}
+	var result []*ast.CompositeLit
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		x := n.(*ast.CompositeLit)
+
+		if !IsSchemaMap(pass, x) {
+			return
+		}
+
+		result = append(result, x)
+	})
+
+	return result, nil
+}
+
+func IsSchemaMap(pass *analysis.Pass, cl *ast.CompositeLit) bool {
+	switch v := cl.Type.(type) {
+	default:
+		return false
+	case *ast.MapType:
+		switch k := v.Key.(type) {
+		default:
+			return false
+		case *ast.Ident:
+			if k.Name != "string" {
+				return false
+			}
+		}
+
+		switch mv := v.Value.(type) {
+		default:
+			return false
+		case *ast.StarExpr:
+			switch x := mv.X.(type) {
+			default:
+				return false
+			case *ast.SelectorExpr:
+				switch x2 := x.X.(type) {
+				default:
+					return false
+				case *ast.Ident:
+					if x2.Name != "schema" {
+						return false
+					}
+				}
+
+				if x.Sel.Name != "Schema" {
+					return false
+				}
+			}
+
+		}
+	}
+	return true
+}

--- a/passes/schemaschema/schemaschema.go
+++ b/passes/schemaschema/schemaschema.go
@@ -32,13 +32,13 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	var result []*ast.CompositeLit
 
 	for _, smap := range schemamaps {
-		result = append(result, schemamap.SchemaAttributes(smap)...)
+		result = append(result, schemamap.GetSchemaAttributes(smap)...)
 	}
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
 		x := n.(*ast.CompositeLit)
 
-		if !IsSchemaSchema(pass, x) {
+		if !isSchemaSchema(pass, x) {
 			return
 		}
 
@@ -48,7 +48,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return result, nil
 }
 
-func IsSchemaSchema(pass *analysis.Pass, cl *ast.CompositeLit) bool {
+func isSchemaSchema(pass *analysis.Pass, cl *ast.CompositeLit) bool {
 	switch v := cl.Type.(type) {
 	default:
 		return false


### PR DESCRIPTION
This PR adds the schemamap finder to the linter. It also updates the current schemaschema finder to include attributes held in the schema map.


```
ok  	github.com/bflad/tfproviderlint/passes/AT001	(cached)
ok  	github.com/bflad/tfproviderlint/passes/AT002	(cached)
ok  	github.com/bflad/tfproviderlint/passes/AT003	(cached)
ok  	github.com/bflad/tfproviderlint/passes/AT004	(cached)
ok  	github.com/bflad/tfproviderlint/passes/R001	(cached)
ok  	github.com/bflad/tfproviderlint/passes/R002	(cached)
ok  	github.com/bflad/tfproviderlint/passes/R003	(cached)
ok  	github.com/bflad/tfproviderlint/passes/R004	(cached)
ok  	github.com/bflad/tfproviderlint/passes/S001	5.511s
ok  	github.com/bflad/tfproviderlint/passes/S002	(cached)
ok  	github.com/bflad/tfproviderlint/passes/S003	(cached)
ok  	github.com/bflad/tfproviderlint/passes/S004	5.018s
ok  	github.com/bflad/tfproviderlint/passes/S005	5.672s
ok  	github.com/bflad/tfproviderlint/passes/S006	5.581s
```