### PR TITLE
passes/AT001: Ignore file names beginning with data_source_

### DIFF
--- a/passes/AT001/README.md
+++ b/passes/AT001/README.md
@@ -3,6 +3,7 @@
 The AT001 analyzer reports likely incorrect uses of `TestCase`
 which do not define a `CheckDestroy` function. `CheckDestroy` is used to verify
 that test infrastructure has been removed at the end of an acceptance test.
+Ignores file names that begin with `data_source_`.
 
 More information can be found at:
 https://www.terraform.io/docs/extend/testing/acceptance-tests/testcase.html#checkdestroy

--- a/passes/AT001/testdata/src/a/data_source_prefix_ignore.go
+++ b/passes/AT001/testdata/src/a/data_source_prefix_ignore.go
@@ -1,0 +1,15 @@
+package a
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func ffilenameignore() {
+	var t *testing.T
+
+	_ = resource.TestCase{}
+
+	resource.Test(t, resource.TestCase{})
+}


### PR DESCRIPTION
Closes #23

Rather than go through the extra effort of supporting a new flag, we will just ignore data source files until there is a specific ask to support them.

```
?   	github.com/bflad/tfproviderlint/cmd/tfproviderlint	[no test files]
?   	github.com/bflad/tfproviderlint/helper/terraformtype	[no test files]
ok  	github.com/bflad/tfproviderlint/passes/AT001	12.440s
ok  	github.com/bflad/tfproviderlint/passes/AT002	3.824s
ok  	github.com/bflad/tfproviderlint/passes/AT003	4.602s
ok  	github.com/bflad/tfproviderlint/passes/AT004	15.277s
ok  	github.com/bflad/tfproviderlint/passes/R001	12.602s
ok  	github.com/bflad/tfproviderlint/passes/R002	13.255s
ok  	github.com/bflad/tfproviderlint/passes/R003	10.458s
ok  	github.com/bflad/tfproviderlint/passes/R004	12.979s
ok  	github.com/bflad/tfproviderlint/passes/S001	12.708s
ok  	github.com/bflad/tfproviderlint/passes/S002	13.226s
ok  	github.com/bflad/tfproviderlint/passes/S003	9.121s
ok  	github.com/bflad/tfproviderlint/passes/S004	7.522s
ok  	github.com/bflad/tfproviderlint/passes/S005	8.194s
ok  	github.com/bflad/tfproviderlint/passes/S006	7.504s
?   	github.com/bflad/tfproviderlint/passes/acctestcase	[no test files]
?   	github.com/bflad/tfproviderlint/passes/acctestfunc	[no test files]
?   	github.com/bflad/tfproviderlint/passes/commentignore	[no test files]
?   	github.com/bflad/tfproviderlint/passes/resourcedataset	[no test files]
?   	github.com/bflad/tfproviderlint/passes/schemamap	[no test files]
?   	github.com/bflad/tfproviderlint/passes/schemaresource	[no test files]
?   	github.com/bflad/tfproviderlint/passes/schemaschema	[no test files]
```