### PR TITLE
Adds the `-version` and `-V` flags to output the version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ brews:
   install: |
     bin.install "tfproviderlint"
   test: |
-    system "#{bin}/tfproviderlint -v"
+    system "#{bin}/tfproviderlint -V"
 builds:
 -
   env:
@@ -32,6 +32,10 @@ builds:
   goarch:
   - amd64
   - 386
+  ldflags:
+    - -s -w -X github.com/bflad/tfproviderlint/version.Version={{.Version}}       \
+            -X github.com/bflad/tfproviderlint/version.VersionPrerelease=         \
+            -X github.com/bflad/tfproviderlint/version.GitCommit={{.ShortCommit}}
   main: ./cmd/tfproviderlint
 changelog:
   skip: true

--- a/cmd/tfproviderlint/flags.go
+++ b/cmd/tfproviderlint/flags.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bflad/tfproviderlint/version"
+)
+
+func addVersionFlag() {
+	flag.Var(versionFlag{}, "V", "print version and exit")
+	flag.Var(versionFlag{}, "version", "print version and exit")
+}
+
+type versionFlag struct{}
+
+func (versionFlag) IsBoolFlag() bool { return true }
+func (versionFlag) Get() interface{} { return nil }
+func (versionFlag) String() string   { return "" }
+func (versionFlag) Set(s string) error {
+	name := os.Args[0]
+	name = name[strings.LastIndex(name, `/`)+1:]
+	name = name[strings.LastIndex(name, `\`)+1:]
+	name = strings.TrimSuffix(name, ".exe")
+
+	// The go command uses -V=full to get a unique identifier for this tool.
+	// Use a fully specified version in that case.
+	fmt.Printf("%s %s\n", name, version.GetVersion().VersionNumber(s == "full"))
+	os.Exit(0)
+
+	return nil
+}

--- a/cmd/tfproviderlint/tfproviderlint.go
+++ b/cmd/tfproviderlint/tfproviderlint.go
@@ -43,6 +43,8 @@ import (
 )
 
 func main() {
+	addVersionFlag()
+
 	multichecker.Main(
 		AT001.Analyzer,
 		AT002.Analyzer,

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,65 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+)
+
+var (
+	// The git commit that was compiled. This will be filled in by the compiler.
+	GitCommit string
+
+	// The main version number that is being run at the moment.
+	Version = "0.6.1"
+
+	// A pre-release marker for the version. If this is "" (empty string)
+	// then it means that it is a final release. Otherwise, this is a pre-release
+	// such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+
+	// VersionMetadata is metadata further describing the build type.
+	VersionMetadata = ""
+)
+
+// VersionInfo
+type VersionInfo struct {
+	Revision          string
+	Version           string
+	VersionPrerelease string
+	VersionMetadata   string
+}
+
+func GetVersion() *VersionInfo {
+	ver := Version
+	rel := VersionPrerelease
+	md := VersionMetadata
+
+	return &VersionInfo{
+		Revision:          GitCommit,
+		Version:           ver,
+		VersionPrerelease: rel,
+		VersionMetadata:   md,
+	}
+}
+
+// VersionNumber returns a version string for the application.
+// Includes the revision information when rev is true.
+func (c *VersionInfo) VersionNumber(rev bool) string {
+	var versionString bytes.Buffer
+
+	fmt.Fprintf(&versionString, "v%s", c.Version)
+
+	if c.VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
+	}
+
+	if c.VersionMetadata != "" {
+		fmt.Fprintf(&versionString, "+%s", c.VersionMetadata)
+	}
+
+	if rev && c.Revision != "" {
+		fmt.Fprintf(&versionString, " (%s)", c.Revision)
+	}
+
+	return versionString.String()
+}


### PR DESCRIPTION
Adds the `-version` and `-V` flags to output the version. Adds `ldflags` for GoReleaser to specify version information.

Related to #22 

Output:
```
$ tfproviderlint -V
tfproviderlint v0.6.1

$ tfproviderlint -V=full
tfproviderlint v0.6.1 (abc123)
```