### PR TITLE
Fix two bugs in basiclit helper & add test

### DIFF
--- a/helper/astutils/basiclit.go
+++ b/helper/astutils/basiclit.go
@@ -2,8 +2,8 @@ package astutils
 
 import (
 	"go/ast"
+	"go/token"
 	"strconv"
-	"strings"
 )
 
 // ExprBoolValue fetches a bool value from the Expr
@@ -29,8 +29,7 @@ func ExprBoolValue(e ast.Expr) *bool {
 func ExprIntValue(e ast.Expr) *int {
 	switch v := e.(type) {
 	case *ast.BasicLit:
-		stringValue := strings.Trim(v.Value, `"`)
-		intValue, err := strconv.Atoi(stringValue)
+		intValue, err := strconv.Atoi(v.Value)
 
 		if err != nil {
 			return nil
@@ -47,8 +46,10 @@ func ExprIntValue(e ast.Expr) *int {
 func ExprStringValue(e ast.Expr) *string {
 	switch v := e.(type) {
 	case *ast.BasicLit:
-		stringValue := strings.Trim(v.Value, `"`)
-
+		if v.Kind != token.STRING {
+			return nil
+		}
+		stringValue, _ := strconv.Unquote(v.Value) // can assume well-formed Go
 		return &stringValue
 	}
 

--- a/helper/astutils/basiclit_test.go
+++ b/helper/astutils/basiclit_test.go
@@ -1,0 +1,187 @@
+package astutils
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+)
+
+func TestExprBoolValue(t *testing.T) {
+	cases := []struct {
+		desc       string
+		assignExpr string
+		expect     *bool
+	}{
+		{
+			"bool literal",
+			`_ = true`,
+			newPtr(true).(*bool),
+		},
+		{
+			"not bool literal",
+			`_ = "true"`,
+			nil,
+		},
+		{
+			"nil",
+			"_ = nil",
+			nil,
+		},
+	}
+
+	code := `package main
+
+func f() {
+`
+	for _, c := range cases {
+		code += "\t" + c.assignExpr + "\n"
+	}
+	code += "}"
+
+	var fset token.FileSet
+	f, _ := parser.ParseFile(&fset, "foo.go", code, 0)
+	mainBody := f.Decls[0].(*ast.FuncDecl).Body.List
+	for i, c := range cases {
+		astmt := mainBody[i].(*ast.AssignStmt)
+		actual := ExprBoolValue(astmt.Rhs[0])
+		switch {
+		case actual == nil && c.expect == nil:
+			continue
+		case actual != nil && c.expect != nil:
+			if *actual == *c.expect {
+				continue
+			}
+			t.Fatalf("%s: %v (expect: %v)", c.desc, *actual, *c.expect)
+		case actual == nil && c.expect != nil:
+			t.Fatalf("%s: nil (expect: %v)", c.desc, *c.expect)
+		case actual != nil && c.expect == nil:
+			t.Fatalf("%s: %v (expect: nil)", c.desc, *actual)
+		}
+	}
+}
+
+func TestExprIntValue(t *testing.T) {
+	cases := []struct {
+		desc       string
+		assignExpr string
+		expect     *int
+	}{
+		{
+			"int literal",
+			`_ = 123`,
+			newPtr(123).(*int),
+		},
+		{
+			"not int literal (string)",
+			`_ = "123"`,
+			nil,
+		},
+		{
+			"not int literal (bool)",
+			`_ = false`,
+			nil,
+		},
+		{
+			"nil",
+			"_ = nil",
+			nil,
+		},
+	}
+
+	code := `package main
+
+func f() {
+`
+	for _, c := range cases {
+		code += "\t" + c.assignExpr + "\n"
+	}
+	code += "}"
+
+	var fset token.FileSet
+	f, _ := parser.ParseFile(&fset, "foo.go", code, 0)
+	mainBody := f.Decls[0].(*ast.FuncDecl).Body.List
+	for i, c := range cases {
+		astmt := mainBody[i].(*ast.AssignStmt)
+		actual := ExprIntValue(astmt.Rhs[0])
+		switch {
+		case actual == nil && c.expect == nil:
+			continue
+		case actual != nil && c.expect != nil:
+			if *actual == *c.expect {
+				continue
+			}
+			t.Fatalf("%s: %v (expect: %v)", c.desc, *actual, *c.expect)
+		case actual == nil && c.expect != nil:
+			t.Fatalf("%s: nil (expect: %v)", c.desc, *c.expect)
+		case actual != nil && c.expect == nil:
+			t.Fatalf("%s: %v (expect: nil)", c.desc, *actual)
+		}
+	}
+}
+
+func TestExprStringValue(t *testing.T) {
+	cases := []struct {
+		desc       string
+		assignExpr string
+		expect     *string
+	}{
+		{
+			"string with double quotes",
+			`_ = "abc"`,
+			newPtr("abc").(*string),
+		},
+		{
+			"string with backtick quotes",
+			"_ = `abc`",
+			newPtr("abc").(*string),
+		},
+		{
+			"not string literal",
+			"_ = 123",
+			nil,
+		},
+		{
+			"nil",
+			"_ = nil",
+			nil,
+		},
+	}
+
+	code := `package main
+
+func f() {
+`
+	for _, c := range cases {
+		code += "\t" + c.assignExpr + "\n"
+	}
+	code += "}"
+
+	var fset token.FileSet
+	f, _ := parser.ParseFile(&fset, "foo.go", code, 0)
+	mainBody := f.Decls[0].(*ast.FuncDecl).Body.List
+	for i, c := range cases {
+		astmt := mainBody[i].(*ast.AssignStmt)
+		actual := ExprStringValue(astmt.Rhs[0])
+		switch {
+		case actual == nil && c.expect == nil:
+			continue
+		case actual != nil && c.expect != nil:
+			if *actual == *c.expect {
+				continue
+			}
+			t.Fatalf("%s: %v (expect: %v)", c.desc, *actual, *c.expect)
+		case actual == nil && c.expect != nil:
+			t.Fatalf("%s: nil (expect: %v)", c.desc, *c.expect)
+		case actual != nil && c.expect == nil:
+			t.Fatalf("%s: %v (expect: nil)", c.desc, *actual)
+		}
+	}
+}
+
+func newPtr(v interface{}) interface{} {
+	rv := reflect.New(reflect.ValueOf(v).Type())
+	rv.Elem().Set(reflect.ValueOf(v))
+	return rv.Interface()
+}


### PR DESCRIPTION
1. `ExprStringValue` should differentiate `nil` among other string
   literal. Also, use `strconv.Unquote` to handle kinds of quotes.
2. `ExprIntValue` should only works for int literal only (previously it
   also works for string literal whose content is int).