### PR TITLE
Add SuggestedFixes to Deprecation with Removal Linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 BREAKING CHANGES
 
-* helper/analysisutils: `DeprecatedWithReplacementSelectorExprAnalyzer` and `DeprecatedWithReplacementSelectorExprRunner` now expects package paths (e.g. `github.com/hashicorp/terraform-plugin-sdk/helper/validation`) instead of just package names (e.g. `validation`)
+* helper/analysisutils: `DeprecatedReceiverMethodSelectorExprAnalyzer` and `DeprecatedReceiverMethodSelectorExprRunner` now expect an `*ast.CallExpr` analyzer and package path (e.g. `github.com/hashicorp/terraform-plugin-sdk/helper/validation`) instead of just package name (e.g. `validation`)
+* helper/analysisutils: `DeprecatedWithReplacementSelectorExprAnalyzer` and `DeprecatedWithReplacementSelectorExprRunner` now expect package paths (e.g. `github.com/hashicorp/terraform-plugin-sdk/helper/validation`) instead of just package names (e.g. `validation`)
 
 ENHANCEMENTS
 
+* helper/analysisutils: `DeprecatedReceiverMethodSelectorExprRunner` now implements `SuggestedFixes`
 * helper/analysisutils: `DeprecatedWithReplacementSelectorExprRunner` now implements `SuggestedFixes`
+* passes/R007: Support suggested fix
+* passes/R008: Support suggested fix
 * passes/V002: Support suggested fix
 * passes/V003: Support suggested fix
 * passes/V004: Support suggested fix

--- a/helper/analysisutils/analyzers.go
+++ b/helper/analysisutils/analyzers.go
@@ -12,22 +12,23 @@ import (
 )
 
 // DeprecatedReceiverMethodSelectorExprAnalyzer returns an Analyzer for deprecated *ast.SelectorExpr
-func DeprecatedReceiverMethodSelectorExprAnalyzer(analyzerName string, selectorExprAnalyzer *analysis.Analyzer, packageName, typeName, methodName string) *analysis.Analyzer {
+func DeprecatedReceiverMethodSelectorExprAnalyzer(analyzerName string, callExprAnalyzer, selectorExprAnalyzer *analysis.Analyzer, packagePath, typeName, methodName string) *analysis.Analyzer {
 	doc := fmt.Sprintf(`check for deprecated %[2]s.%[3]s usage
 
 The %[1]s analyzer reports usage of the deprecated:
 
 %[2]s.%[3]s
-`, analyzerName, packageName, typeName, methodName)
+`, analyzerName, packagePath, typeName, methodName)
 
 	return &analysis.Analyzer{
 		Name: analyzerName,
 		Doc:  doc,
 		Requires: []*analysis.Analyzer{
+			callExprAnalyzer,
 			commentignore.Analyzer,
 			selectorExprAnalyzer,
 		},
-		Run: DeprecatedReceiverMethodSelectorExprRunner(analyzerName, selectorExprAnalyzer, packageName, typeName, methodName),
+		Run: DeprecatedReceiverMethodSelectorExprRunner(analyzerName, callExprAnalyzer, selectorExprAnalyzer, packagePath, typeName, methodName),
 	}
 }
 

--- a/passes/R007/R007.go
+++ b/passes/R007/R007.go
@@ -3,13 +3,15 @@ package R007
 import (
 	"github.com/bflad/tfproviderlint/helper/analysisutils"
 	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema"
+	"github.com/bflad/tfproviderlint/passes/helper/schema/resourcedatapartialcallexpr"
 	"github.com/bflad/tfproviderlint/passes/helper/schema/resourcedatapartialselectorexpr"
 )
 
 var Analyzer = analysisutils.DeprecatedReceiverMethodSelectorExprAnalyzer(
 	"R007",
+	resourcedatapartialcallexpr.Analyzer,
 	resourcedatapartialselectorexpr.Analyzer,
-	schema.PackageName,
+	schema.PackagePath,
 	schema.TypeNameResourceData,
 	"Partial",
 )

--- a/passes/R007/R007_test.go
+++ b/passes/R007/R007_test.go
@@ -3,6 +3,7 @@ package R007_test
 import (
 	"testing"
 
+	"github.com/bflad/tfproviderlint/helper/analysisfixtest"
 	"github.com/bflad/tfproviderlint/passes/R007"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
@@ -10,4 +11,9 @@ import (
 func TestR007(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, R007.Analyzer, "a")
+}
+
+func TestAnalyzerFixes(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysisfixtest.Run(t, testdata, R007.Analyzer, "a")
 }

--- a/passes/R007/testdata/src/a/main.go
+++ b/passes/R007/testdata/src/a/main.go
@@ -16,15 +16,15 @@ func f() {
 
 	// Failing
 
-	d.Partial(true)  // want "deprecated \\(schema.ResourceData\\).Partial"
-	d.Partial(false) // want "deprecated \\(schema.ResourceData\\).Partial"
+	d.Partial(true)  // want "deprecated d.Partial"
+	d.Partial(false) // want "deprecated d.Partial"
 
 	fResourceFunc(&d, nil)
 }
 
 func fResourceFunc(d *schema.ResourceData, meta interface{}) error {
-	d.Partial(true)  // want "deprecated \\(schema.ResourceData\\).Partial"
-	d.Partial(false) // want "deprecated \\(schema.ResourceData\\).Partial"
+	d.Partial(true)  // want "deprecated d.Partial"
+	d.Partial(false) // want "deprecated d.Partial"
 
 	return nil
 }

--- a/passes/R007/testdata/src/a_fixed/main.go
+++ b/passes/R007/testdata/src/a_fixed/main.go
@@ -9,20 +9,22 @@ func f() {
 
 	// Comment ignored
 
-	//lintignore:R008
-	d.SetPartial("test")
+	//lintignore:R007
+	d.Partial(true)
 
-	d.SetPartial("test") //lintignore:R008
+	d.Partial(true) //lintignore:R007
 
 	// Failing
 
-	d.SetPartial("test") // want "deprecated d.SetPartial"
+	// want "deprecated d.Partial"
+	// want "deprecated d.Partial"
 
 	fResourceFunc(&d, nil)
 }
 
 func fResourceFunc(d *schema.ResourceData, meta interface{}) error {
-	d.SetPartial("test") // want "deprecated d.SetPartial"
+	// want "deprecated d.Partial"
+	// want "deprecated d.Partial"
 
 	return nil
 }

--- a/passes/R008/R008.go
+++ b/passes/R008/R008.go
@@ -3,13 +3,15 @@ package R008
 import (
 	"github.com/bflad/tfproviderlint/helper/analysisutils"
 	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema"
+	"github.com/bflad/tfproviderlint/passes/helper/schema/resourcedatasetpartialcallexpr"
 	"github.com/bflad/tfproviderlint/passes/helper/schema/resourcedatasetpartialselectorexpr"
 )
 
 var Analyzer = analysisutils.DeprecatedReceiverMethodSelectorExprAnalyzer(
 	"R008",
+	resourcedatasetpartialcallexpr.Analyzer,
 	resourcedatasetpartialselectorexpr.Analyzer,
-	schema.PackageName,
+	schema.PackagePath,
 	schema.TypeNameResourceData,
 	"SetPartial",
 )

--- a/passes/R008/R008_test.go
+++ b/passes/R008/R008_test.go
@@ -3,6 +3,7 @@ package R008_test
 import (
 	"testing"
 
+	"github.com/bflad/tfproviderlint/helper/analysisfixtest"
 	"github.com/bflad/tfproviderlint/passes/R008"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
@@ -10,4 +11,9 @@ import (
 func TestR008(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, R008.Analyzer, "a")
+}
+
+func TestAnalyzerFixes(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysisfixtest.Run(t, testdata, R008.Analyzer, "a")
 }

--- a/passes/R008/testdata/src/a_fixed/main.go
+++ b/passes/R008/testdata/src/a_fixed/main.go
@@ -16,13 +16,13 @@ func f() {
 
 	// Failing
 
-	d.SetPartial("test") // want "deprecated d.SetPartial"
+	// want "deprecated d.SetPartial"
 
 	fResourceFunc(&d, nil)
 }
 
 func fResourceFunc(d *schema.ResourceData, meta interface{}) error {
-	d.SetPartial("test") // want "deprecated d.SetPartial"
+	// want "deprecated d.SetPartial"
 
 	return nil
 }

--- a/passes/helper/schema/resourcedatapartialcallexpr/resourcedatapartialcallexpr.go
+++ b/passes/helper/schema/resourcedatapartialcallexpr/resourcedatapartialcallexpr.go
@@ -1,0 +1,14 @@
+package resourcedatapartialcallexpr
+
+import (
+	"github.com/bflad/tfproviderlint/helper/analysisutils"
+	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema"
+)
+
+var Analyzer = analysisutils.ReceiverMethodCallExprAnalyzer(
+	"resourcedatapartialcallexpr",
+	schema.IsReceiverMethod,
+	schema.PackagePath,
+	schema.TypeNameResourceData,
+	"Partial",
+)

--- a/passes/helper/schema/resourcedatapartialcallexpr/resourcedatapartialcallexpr_test.go
+++ b/passes/helper/schema/resourcedatapartialcallexpr/resourcedatapartialcallexpr_test.go
@@ -1,0 +1,15 @@
+package resourcedatapartialcallexpr
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+func TestValidateAnalyzer(t *testing.T) {
+	err := analysis.Validate([]*analysis.Analyzer{Analyzer})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/passes/helper/schema/resourcedatasetpartialcallexpr/resourcedatasetpartialcallexpr.go
+++ b/passes/helper/schema/resourcedatasetpartialcallexpr/resourcedatasetpartialcallexpr.go
@@ -1,0 +1,14 @@
+package resourcedatasetpartialcallexpr
+
+import (
+	"github.com/bflad/tfproviderlint/helper/analysisutils"
+	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema"
+)
+
+var Analyzer = analysisutils.ReceiverMethodCallExprAnalyzer(
+	"resourcedatasetpartialcallexpr",
+	schema.IsReceiverMethod,
+	schema.PackagePath,
+	schema.TypeNameResourceData,
+	"SetPartial",
+)

--- a/passes/helper/schema/resourcedatasetpartialcallexpr/resourcedatasetpartialcallexpr_test.go
+++ b/passes/helper/schema/resourcedatasetpartialcallexpr/resourcedatasetpartialcallexpr_test.go
@@ -1,0 +1,15 @@
+package resourcedatasetpartialcallexpr
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+func TestValidateAnalyzer(t *testing.T) {
+	err := analysis.Validate([]*analysis.Analyzer{Analyzer})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #109

These reports can now be automatically fixed via editors supporting suggested fixes functionality and the command line via the -fix flag.