### PR TITLE
Ignore more versions of data_source tests

### DIFF
--- a/passes/AT001/AT001.go
+++ b/passes/AT001/AT001.go
@@ -41,7 +41,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	for _, testCase := range testCases {
 		fileName := filepath.Base(pass.Fset.File(testCase.AstCompositeLit.Pos()).Name())
 
-		if strings.HasPrefix(fileName, "data_source_") {
+		if strings.Contains(fileName, "data_source_") || strings.HasSuffix(fileName, "_data_source_test.go") {
 			continue
 		}
 


### PR DESCRIPTION
In azurerm provider lots of files end with `_data_source_test.go`, rather than start with it resulting in quite a few false positives. After a chat with @tombuildsstuff and @jackofallops - here's a proposed PR.

Thanks!