### PR TITLE
[fix] AT009 detects wrong usage

### DIFF
--- a/passes/AT009/AT009.go
+++ b/passes/AT009/AT009.go
@@ -39,7 +39,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			continue
 		}
 
-		if !acctest.IsConst(callExpr.Args[1], pass.TypesInfo, acctest.ConstNameCharSetAlpha) {
+		if !acctest.IsConst(callExpr.Args[1], pass.TypesInfo, acctest.ConstNameCharSetAlphaNum) {
 			continue
 		}
 

--- a/passes/AT009/testdata/src/a/main.go
+++ b/passes/AT009/testdata/src/a/main.go
@@ -16,11 +16,10 @@ func f() {
 
 	// Failing
 
-	_ = acctest.RandStringFromCharSet(1, acctest.CharSetAlpha) // want "should use RandString call instead"
+	_ = acctest.RandStringFromCharSet(1, acctest.CharSetAlphaNum) // want "should use RandString call instead"
 
 	// Passing
-
-	_ = acctest.RandStringFromCharSet(1, acctest.CharSetAlphaNum)
+	_ = acctest.RandStringFromCharSet(1, acctest.CharSetAlpha)
 	_ = acctest.RandStringFromCharSet(1, "abc123")
 	_ = acctest.RandString(1)
 }


### PR DESCRIPTION
AT009 would complain about

```go
acctest.RandStringFromCharSet(1, acctest.CharSetAlpha)
```

but should complain about

```go
acctest.RandStringFromCharSet(1, acctest.CharSetAlphaNum)
```

since the latter form is equivalent to `acctest.RandString(1)`

Fixes #213