### PR TITLE
Update R014 to work with context CRUD functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Standard lint checks are enabled by default in the `tfproviderlint` tool. Opt-in
 | [R011](passes/R011) | check for `Resource` that configure `MigrateState` | AST |
 | [R012](passes/R012) | check for data source `Resource` that configure `CustomizeDiff` | AST |
 | [R013](passes/R013) | check for `map[string]*Resource` that resource names contain at least one underscore | AST |
-| [R014](passes/R014) | check for `CreateFunc`, `DeleteFunc`, `ReadFunc`, and `UpdateFunc` parameter naming | AST |
+| [R014](passes/R014) | check for `CreateContext`, `DeleteContext`, `ReadContext`, and `UpdateContext` parameter naming | AST |
 | [R015](passes/R015) | check for `(*schema.ResourceData).SetId()` receiver method usage with unstable `resource.UniqueId()` value | AST |
 | [R016](passes/R016) | check for `(*schema.ResourceData).SetId()` receiver method usage with unstable `resource.PrefixedUniqueId()` value | AST |
 | [R017](passes/R017) | check for `(*schema.ResourceData).SetId()` receiver method usage with unstable `time.Now()` value | AST |

--- a/helper/terraformtype/diag/package.go
+++ b/helper/terraformtype/diag/package.go
@@ -1,0 +1,8 @@
+package diag
+
+import "github.com/bflad/tfproviderlint/helper/terraformtype"
+
+const (
+	PackageModule     = terraformtype.ModuleTerraformPluginSdk
+	PackageModulePath = `diag`
+)

--- a/helper/terraformtype/diag/type_diagnostics.go
+++ b/helper/terraformtype/diag/type_diagnostics.go
@@ -1,0 +1,5 @@
+package diag
+
+const (
+	TypeNameDiagnostics = `Diagnostics`
+)

--- a/passes/R014/R014.go
+++ b/passes/R014/R014.go
@@ -37,13 +37,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		params := crudFunc.Type.Params
+		paramCount := len(params.List)
 
-		if name := astutils.FieldListName(params, 0, 0); name != nil && *name != "_" && *name != "d" {
-			pass.Reportf(params.List[0].Pos(), "%s: *schema.ResourceData parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named d", analyzerName)
+		if name := astutils.FieldListName(params, paramCount-2, 0); name != nil && *name != "_" && *name != "d" {
+			pass.Reportf(params.List[paramCount-2].Pos(), "%s: *schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d", analyzerName)
 		}
 
-		if name := astutils.FieldListName(params, 1, 0); name != nil && *name != "_" && *name != "meta" {
-			pass.Reportf(params.List[1].Pos(), "%s: interface{} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta", analyzerName)
+		if name := astutils.FieldListName(params, paramCount-1, 0); name != nil && *name != "_" && *name != "meta" {
+			pass.Reportf(params.List[paramCount-1].Pos(), "%s: interface{} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta", analyzerName)
 		}
 	}
 

--- a/passes/R014/README.md
+++ b/passes/R014/README.md
@@ -1,6 +1,6 @@
 # R014
 
-The R014 analyzer reports when `CreateFunc`, `DeleteFunc`, `ReadFunc`, and `UpdateFunc` declarations do not use `d` as the name for the `*schema.ResourceData` parameter or `meta` as the name for the `interface{}` parameter. This parameter naming is the standard convention for resources.
+The R014 analyzer reports when `CreateContext`, `DeleteContext`, `ReadContext`, and `UpdateContext` declarations do not use `d` as the name for the `*schema.ResourceData` parameter or `meta` as the name for the `interface{}` parameter. This parameter naming is the standard convention for resources.
 
 ## Flagged Code
 

--- a/passes/R014/testdata/src/a/main.go
+++ b/passes/R014/testdata/src/a/main.go
@@ -17,22 +17,22 @@ func commentIgnoreSecondParameter(d *schema.ResourceData, invalid interface{}) e
 // Failing
 
 func failingAnonymousFirstParameter() {
-	_ = func(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named d"
+	_ = func(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
 		return nil
 	}
 }
 
 func failingAnonymousSecondParameter() {
-	_ = func(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta"
+	_ = func(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
 		return nil
 	}
 }
 
-func failingFirstParameter(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named d"
+func failingFirstParameter(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
 	return nil
 }
 
-func failingSecondParameter(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta"
+func failingSecondParameter(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
 	return nil
 }
 

--- a/passes/R014/testdata/src/a/main_v2.go
+++ b/passes/R014/testdata/src/a/main_v2.go
@@ -17,22 +17,22 @@ func commentIgnoreSecondParameter_v2(d *schema.ResourceData, invalid interface{}
 // Failing
 
 func failingAnonymousFirstParameter_v2() {
-	_ = func(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named d"
+	_ = func(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
 		return nil
 	}
 }
 
 func failingAnonymousSecondParameter_v2() {
-	_ = func(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta"
+	_ = func(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
 		return nil
 	}
 }
 
-func failingFirstParameter_v2(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named d"
+func failingFirstParameter_v2(invalid *schema.ResourceData, meta interface{}) error { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
 	return nil
 }
 
-func failingSecondParameter_v2(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta"
+func failingSecondParameter_v2(d *schema.ResourceData, invalid interface{}) error { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
 	return nil
 }
 

--- a/passes/R014/testdata/src/a/main_v2_context.go
+++ b/passes/R014/testdata/src/a/main_v2_context.go
@@ -1,0 +1,57 @@
+package a
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Comment ignored
+
+//lintignore:R014
+func commentIgnoreFirstParameter_v2_context(ctx context.Context, invalid *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+//lintignore:R014
+func commentIgnoreSecondParameter_v2_context(ctx context.Context, d *schema.ResourceData, invalid interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+// Failing
+
+func failingAnonymousFirstParameter_v2_context() {
+	_ = func(ctx context.Context, invalid *schema.ResourceData, meta interface{}) diag.Diagnostics { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
+		return diag.Diagnostics{}
+	}
+}
+
+func failingAnonymousSecondParameter_v2_context() {
+	_ = func(ctx context.Context, d *schema.ResourceData, invalid interface{}) diag.Diagnostics { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
+		return diag.Diagnostics{}
+	}
+}
+
+func failingFirstParameter_v2_context(ctx context.Context, invalid *schema.ResourceData, meta interface{}) diag.Diagnostics { // want "\\*schema.ResourceData parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named d"
+	return diag.Diagnostics{}
+}
+
+func failingSecondParameter_v2_context(ctx context.Context, d *schema.ResourceData, invalid interface{}) diag.Diagnostics { // want "interface\\{\\} parameter of CreateContext, ReadContext, UpdateContext, or DeleteContext should be named meta"
+	return diag.Diagnostics{}
+}
+
+// Passing
+
+func passingAnonymous_v2_context() {
+	_ = func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		return diag.Diagnostics{}
+	}
+}
+
+func passing_v2_context(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+func passingOther_v2_context(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}

--- a/passes/helper/schema/crudfuncinfo/crudfuncinfo.go
+++ b/passes/helper/schema/crudfuncinfo/crudfuncinfo.go
@@ -4,7 +4,6 @@ import (
 	"go/ast"
 	"reflect"
 
-	"github.com/bflad/tfproviderlint/helper/astutils"
 	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -13,7 +12,7 @@ import (
 
 var Analyzer = &analysis.Analyzer{
 	Name: "crudfuncinfo",
-	Doc:  "find github.com/hashicorp/terraform-plugin-sdk/helper/schema CreateFunc, ReadFunc, UpdateFunc, and DeleteFunc declarations for later passes",
+	Doc:  "find github.com/hashicorp/terraform-plugin-sdk/helper/schema CreateContext, ReadContext, UpdateContext, and DeleteContext declarations for later passes",
 	Requires: []*analysis.Analyzer{
 		inspect.Analyzer,
 	},
@@ -30,25 +29,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	var result []*schema.CRUDFuncInfo
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		funcType := astutils.FuncTypeFromNode(n)
-
-		if funcType == nil {
-			return
+		if schema.IsFuncTypeCRUDFunc(n, pass.TypesInfo) {
+			result = append(result, schema.NewCRUDFuncInfo(n, pass.TypesInfo))
 		}
-
-		if !astutils.IsFieldListTypeModulePackageType(funcType.Params, 0, pass.TypesInfo, schema.PackageModule, schema.PackageModulePath, schema.TypeNameResourceData) {
-			return
-		}
-
-		if !astutils.IsFieldListType(funcType.Params, 1, astutils.IsExprTypeInterface) {
-			return
-		}
-
-		if !astutils.IsFieldListType(funcType.Results, 0, astutils.IsExprTypeError) {
-			return
-		}
-
-		result = append(result, schema.NewCRUDFuncInfo(n, pass.TypesInfo))
 	})
 
 	return result, nil


### PR DESCRIPTION
Fixes #220 

### Notes

The update to R014 still works with the deprecated functions, but now it works with the `*Context` CRUD functions too.

I changed the check's failure message to use the `*Context` function names in all cases, for simplicity, since I figured the other functions are deprecated anyway.

I modeled the change after the way `type_customizedifffunc.go` contains the `IsFuncTypeCustomizeDiffFunc` function, rather than having that logic in the pass, and also the way it checks for two different function signatures.

I also compiled this and ran it against some real provider code using the `*Context` functions to verify it works.