### PR TITLE
helper/terraformtype/helper/schema: Prevent panics with function or variable `Elem` field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ ENHANCEMENTS
 * passes/helper/schema/crudfuncinfo: Support `CreateContextFunc`, `DeleteContextFunc`, `ReadContextFunc`, and `UpdateContextFunc` matches (#221)
 * passes/R014: Support `CreateContextFunc`, `DeleteContextFunc`, `ReadContextFunc`, and `UpdateContextFunc` reports (#221)
 
+BUG FIXES
+
+* helper/terraformtype/helper/schema: Prevent panics with function or variable `Elem` field values
+
 # v0.21.0
 
 FEATURES

--- a/helper/terraformtype/helper/schema/type_schema.go
+++ b/helper/terraformtype/helper/schema/type_schema.go
@@ -208,7 +208,7 @@ func NewSchemaInfo(cl *ast.CompositeLit, info *types.Info) *SchemaInfo {
 
 	if kvExpr := result.Fields[SchemaFieldElem]; kvExpr != nil && astutils.ExprValue(kvExpr.Value) != nil {
 		if uexpr, ok := kvExpr.Value.(*ast.UnaryExpr); ok {
-			if cl := uexpr.X.(*ast.CompositeLit); ok {
+			if cl, ok := uexpr.X.(*ast.CompositeLit); ok {
 				switch {
 				case IsTypeResource(info.TypeOf(cl.Type)):
 					resourceInfo := NewResourceInfo(cl, info)

--- a/passes/S001/testdata/src/a/main.go
+++ b/passes/S001/testdata/src/a/main.go
@@ -23,9 +23,77 @@ func f() {
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
 
-	_ = map[string]*schema.Schema{ 
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: resourceSchemaFunc(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: resourceSchemaFunc(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: resourceSchemaVar,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: resourceSchemaVar,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: schemaVar,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: schemaVar,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: schemaFunc(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: schemaFunc(),
+	}
+
+	_ = map[string]*schema.Schema{
 		"name": { // want "schema of TypeList or TypeSet should include Elem"
-			Type:     schema.TypeList,
+			Type: schema.TypeList,
 		},
 	}
+}
+
+func resourceSchemaFunc() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"test": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+var resourceSchemaVar = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"test": {
+			Type: schema.TypeString,
+		},
+	},
+}
+
+func schemaFunc() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+	}
+}
+
+var schemaVar = &schema.Schema{
+	Type: schema.TypeString,
 }

--- a/passes/S001/testdata/src/a/main_v2.go
+++ b/passes/S001/testdata/src/a/main_v2.go
@@ -23,9 +23,77 @@ func f_v2() {
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
 
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: resourceSchemaFunc_v2(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: resourceSchemaFunc_v2(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: resourceSchemaVar_v2,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: resourceSchemaVar_v2,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: schemaVar_v2,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: schemaVar_v2,
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeList,
+		Elem: schemaFunc_v2(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeSet,
+		Elem: schemaFunc_v2(),
+	}
+
 	_ = map[string]*schema.Schema{
 		"name": { // want "schema of TypeList or TypeSet should include Elem"
 			Type: schema.TypeList,
 		},
 	}
+}
+
+func resourceSchemaFunc_v2() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"test": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+var resourceSchemaVar_v2 = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"test": {
+			Type: schema.TypeString,
+		},
+	},
+}
+
+func schemaFunc_v2() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+	}
+}
+
+var schemaVar_v2 = &schema.Schema{
+	Type: schema.TypeString,
 }

--- a/passes/S006/testdata/src/a/main.go
+++ b/passes/S006/testdata/src/a/main.go
@@ -14,9 +14,29 @@ func f() {
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
 
-	_ = map[string]*schema.Schema{ 
+	_ = schema.Schema{
+		Type: schema.TypeMap,
+		Elem: schemaFunc(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeMap,
+		Elem: schemaVar,
+	}
+
+	_ = map[string]*schema.Schema{
 		"name": { // want "schema of TypeMap should include Elem"
 			Type: schema.TypeMap,
 		},
 	}
+}
+
+func schemaFunc() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+	}
+}
+
+var schemaVar = &schema.Schema{
+	Type: schema.TypeString,
 }

--- a/passes/S006/testdata/src/a/main_v2.go
+++ b/passes/S006/testdata/src/a/main_v2.go
@@ -14,9 +14,29 @@ func f_v2() {
 		Elem: &schema.Schema{Type: schema.TypeString},
 	}
 
+	_ = schema.Schema{
+		Type: schema.TypeMap,
+		Elem: schemaFunc_v2(),
+	}
+
+	_ = schema.Schema{
+		Type: schema.TypeMap,
+		Elem: schemaVar_v2,
+	}
+
 	_ = map[string]*schema.Schema{
 		"name": { // want "schema of TypeMap should include Elem"
 			Type: schema.TypeMap,
 		},
 	}
+}
+
+func schemaFunc_v2() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeString,
+	}
+}
+
+var schemaVar_v2 = &schema.Schema{
+	Type: schema.TypeString,
 }


### PR DESCRIPTION
Closes #223

Previously with CloudFlare provider:

```
$  tfproviderlint ./cloudflare
panic: interface conversion: ast.Expr is *ast.Ident, not *ast.CompositeLit

goroutine 5153 [running]:
github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema.NewSchemaInfo(0xc000a14680, 0xc001fecfa0, 0xc00208ecd0)
	/Users/bflad/src/github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema/type_schema.go:211 +0x1271
github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema.NewResourceInfo(0xc000a14c80, 0xc001fecfa0, 0xc002d28e01)
	/Users/bflad/src/github.com/bflad/tfproviderlint/helper/terraformtype/helper/schema/type_resource.go:90 +0x33e
github.com/bflad/tfproviderlint/passes/helper/schema/resourceinfo.run.func1(0x13c06a0, 0xc000a14c80)
	/Users/bflad/src/github.com/bflad/tfproviderlint/passes/helper/schema/resourceinfo/resourceinfo.go:37 +0x85
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc003c2e340, 0xc000f66b00, 0x1, 0x1, 0xc000aadb28)
	/Users/bflad/go/pkg/mod/golang.org/x/tools@v0.0.0-20200713011307-fd294ab11aed/go/ast/inspector/inspector.go:77 +0xa2
github.com/bflad/tfproviderlint/passes/helper/schema/resourceinfo.run(0xc003fc2780, 0xc003fc2780, 0x0, 0x0, 0x0)
	/Users/bflad/src/github.com/bflad/tfproviderlint/passes/helper/schema/resourceinfo/resourceinfo.go:30 +0xf1
golang.org/x/tools/go/analysis/internal/checker.(*action).execOnce(0xc0036d1040)
	/Users/bflad/go/pkg/mod/golang.org/x/tools@v0.0.0-20200713011307-fd294ab11aed/go/analysis/internal/checker/checker.go:690 +0x87e
sync.(*Once).doSlow(0xc0036d1040, 0xc000961f90)
	/usr/local/Cellar/go/1.15.8/libexec/src/sync/once.go:66 +0xec
sync.(*Once).Do(...)
	/usr/local/Cellar/go/1.15.8/libexec/src/sync/once.go:57
golang.org/x/tools/go/analysis/internal/checker.(*action).exec(0xc0036d1040)
	/Users/bflad/go/pkg/mod/golang.org/x/tools@v0.0.0-20200713011307-fd294ab11aed/go/analysis/internal/checker/checker.go:579 +0x65
golang.org/x/tools/go/analysis/internal/checker.execAll.func1(0xc0036d1040)
	/Users/bflad/go/pkg/mod/golang.org/x/tools@v0.0.0-20200713011307-fd294ab11aed/go/analysis/internal/checker/checker.go:567 +0x34
created by golang.org/x/tools/go/analysis/internal/checker.execAll
	/Users/bflad/go/pkg/mod/golang.org/x/tools@v0.0.0-20200713011307-fd294ab11aed/go/analysis/internal/checker/checker.go:573 +0x125
```

Now:

```
$ tfproviderlint ./cloudflare
/Users/bflad/src/github.com/cloudflare/terraform-provider-cloudflare/cloudflare/import_cloudflare_load_balancer_monitor_test.go:13:28: AT001: missing CheckDestroy
...
```