### PR TITLE
New Check: AT012: check for files containing multiple acceptance test function name prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES
 
 * **New Check:** `AT010`: check for `TestCase` including `IDRefreshName` implementation
 * **New Check:** `AT011`: check for `TestCase` including `IDRefreshIgnore` implementation without `IDRefreshName`
+* **New Check:** `AT012`: check for files containing multiple acceptance test function name prefixes
 
 # v0.23.0
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Standard lint checks are enabled by default in the `tfproviderlint` tool. Opt-in
 | [AT009](passes/AT009) | check for `acctest.RandStringFromCharSet()` calls that can be simplified to `acctest.RandString()` | AST |
 | [AT010](passes/AT010) | check for `TestCase` including `IDRefreshName` implementation | AST |
 | [AT011](passes/AT011) | check for `TestCase` including `IDRefreshIgnore` implementation without `IDRefreshName` | AST |
+| [AT012](passes/AT012) | check for files containing multiple acceptance test function name prefixes | AST |
 
 ### Standard Resource Checks
 

--- a/passes/AT012/AT012.go
+++ b/passes/AT012/AT012.go
@@ -1,0 +1,118 @@
+package AT012
+
+import (
+	"flag"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"strings"
+
+	"github.com/bflad/tfproviderlint/passes/commentignore"
+	"github.com/bflad/tfproviderlint/passes/testaccfuncdecl"
+	"golang.org/x/tools/go/analysis"
+)
+
+const Doc = `check for test files containing multiple acceptance test function name prefixes
+
+The AT012 analyzer reports likely incorrect uses of multiple TestAcc function
+name prefixes up to the conventional underscore (_) prefix separator within
+the same file. Typically, Terraform acceptance tests should use the same naming
+prefix within one test file so testers can easily run all acceptance tests for
+the file and not miss associated tests.
+
+Optional parameters:
+  - ignored-filenames Comma-separated list of file names to ignore, defaults to none.`
+
+const (
+	acceptanceTestNameSeparator = "_"
+
+	analyzerName = "AT012"
+)
+
+var (
+	ignoredFilenames string
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:  analyzerName,
+	Doc:   Doc,
+	Flags: parseFlags(),
+	Requires: []*analysis.Analyzer{
+		commentignore.Analyzer,
+		testaccfuncdecl.Analyzer,
+	},
+	Run: run,
+}
+
+func isFilenameIgnored(fileName string, fileNameList string) bool {
+	prefixes := strings.Split(fileNameList, ",")
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(fileName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseFlags() flag.FlagSet {
+	var flags = flag.NewFlagSet(analyzerName, flag.ExitOnError)
+	flags.StringVar(&ignoredFilenames, "ignored-filenames", "", "Comma-separated list of file names to ignore")
+	return *flags
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	ignorer := pass.ResultOf[commentignore.Analyzer].(*commentignore.Ignorer)
+	funcDecls := pass.ResultOf[testaccfuncdecl.Analyzer].([]*ast.FuncDecl)
+
+	fileFuncDecls := make(map[*token.File][]*ast.FuncDecl)
+
+	for _, funcDecl := range funcDecls {
+		file := pass.Fset.File(funcDecl.Pos())
+		fileName := filepath.Base(file.Name())
+
+		if ignoredFilenames != "" && isFilenameIgnored(fileName, ignoredFilenames) {
+			continue
+		}
+
+		if ignorer.ShouldIgnore(analyzerName, funcDecl) {
+			continue
+		}
+
+		fileFuncDecls[file] = append(fileFuncDecls[file], funcDecl)
+	}
+
+	for file, funcDecls := range fileFuncDecls {
+		// Map to simplify checking
+		funcNamePrefixes := make(map[string]struct{})
+
+		for _, funcDecl := range funcDecls {
+			funcName := funcDecl.Name.Name
+
+			funcNamePrefixParts := strings.SplitN(funcName, acceptanceTestNameSeparator, 2)
+
+			// Ensure function name includes separator
+			if len(funcNamePrefixParts) != 2 || funcNamePrefixParts[0] == "" || funcNamePrefixParts[1] == "" {
+				continue
+			}
+
+			funcNamePrefix := funcNamePrefixParts[0]
+
+			funcNamePrefixes[funcNamePrefix] = struct{}{}
+		}
+
+		if len(funcNamePrefixes) <= 1 {
+			continue
+		}
+
+		// Easier to print map keys as slice
+		namePrefixes := make([]string, 0, len(funcNamePrefixes))
+		for k := range funcNamePrefixes {
+			namePrefixes = append(namePrefixes, k)
+		}
+
+		pass.Reportf(file.Pos(0), "%s: file contains multiple acceptance test name prefixes: %v", analyzerName, namePrefixes)
+	}
+
+	return nil, nil
+}

--- a/passes/AT012/AT012_test.go
+++ b/passes/AT012/AT012_test.go
@@ -1,0 +1,21 @@
+package AT012_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/bflad/tfproviderlint/passes/AT012"
+)
+
+func TestAT012(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, AT012.Analyzer, "a")
+}
+
+func TestAT012IgnoredFilenames(t *testing.T) {
+	testdata := analysistest.TestData()
+	analyzer := AT012.Analyzer
+	analyzer.Flags.Set("ignored-filenames", "ignored_file_test.go")
+	analysistest.Run(t, testdata, analyzer, "ignoredfilenames")
+}

--- a/passes/AT012/README.md
+++ b/passes/AT012/README.md
@@ -1,0 +1,37 @@
+# AT012
+
+The AT012 analyzer reports likely incorrect uses of multiple `TestAcc` function name prefixes up to the conventional underscore (`_`) prefix separator within the same file. Typically, Terraform acceptance tests should use the same naming prefix within one test file so testers can easily run all acceptance tests for the file and not miss associated tests.
+
+Optional parameters:
+
+- `ignored-filenames` Comma-separated list of file names to ignore, defaults to none.
+
+## Flagged Code
+
+```go
+func TestAccExampleThing1_Test(t *testing.T) { /* ... */ }
+
+func TestAccExampleThing2_Test(t *testing.T) { /* ... */ }
+```
+
+## Passing Code
+
+```go
+func TestAccExampleThing_Test1(t *testing.T) { /* ... */ }
+
+func TestAccExampleThing_Test2(t *testing.T) { /* ... */ }
+```
+
+## Ignoring Reports
+
+In addition to the optional parameters, reports can be ignored by adding a `//lintignore:AT012` Go code comment before any test declaration to ignore, e.g.
+
+```go
+//lintignore:AT012
+func TestAccExampleThing1_Test(t *testing.T) { /* ... */ }
+
+//lintignore:AT012
+func TestAccExampleThing2_Test(t *testing.T) { /* ... */ }
+```
+
+If a file mainly uses one prefix, the code ignores can be simplified to only the non-conforming test declarations.

--- a/passes/AT012/testdata/src/a/comment_ignore_test.go
+++ b/passes/AT012/testdata/src/a/comment_ignore_test.go
@@ -1,0 +1,11 @@
+package a
+
+import (
+	"testing"
+)
+
+//lintignore:AT012
+func TestAccExampleThingCommentIgnore1_Test(t *testing.T) {}
+
+//lintignore:AT012
+func TestAccExampleThingCommentIgnore2_Test(t *testing.T) {}

--- a/passes/AT012/testdata/src/a/failing_test.go
+++ b/passes/AT012/testdata/src/a/failing_test.go
@@ -1,0 +1,10 @@
+// want "file contains multiple acceptance test name prefixes"
+package a
+
+import (
+	"testing"
+)
+
+func TestAccExampleThingFailing1_Test(t *testing.T) {}
+
+func TestAccExampleThingFailing2_Test(t *testing.T) {}

--- a/passes/AT012/testdata/src/a/passing_test.go
+++ b/passes/AT012/testdata/src/a/passing_test.go
@@ -1,0 +1,9 @@
+package a
+
+import (
+	"testing"
+)
+
+func TestAccExampleThing_Passing1(t *testing.T) {}
+
+func TestAccExampleThing_Passing2(t *testing.T) {}

--- a/passes/AT012/testdata/src/ignoredfilenames/ignored_file_test.go
+++ b/passes/AT012/testdata/src/ignoredfilenames/ignored_file_test.go
@@ -1,0 +1,9 @@
+package ignoredfilenames
+
+import (
+	"testing"
+)
+
+func TestAccExampleThingFileIgnored1_Test(t *testing.T) {}
+
+func TestAccExampleThingFileIgnored2_Test(t *testing.T) {}

--- a/passes/checks.go
+++ b/passes/checks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bflad/tfproviderlint/passes/AT009"
 	"github.com/bflad/tfproviderlint/passes/AT010"
 	"github.com/bflad/tfproviderlint/passes/AT011"
+	"github.com/bflad/tfproviderlint/passes/AT012"
 	"github.com/bflad/tfproviderlint/passes/R001"
 	"github.com/bflad/tfproviderlint/passes/R002"
 	"github.com/bflad/tfproviderlint/passes/R003"
@@ -96,6 +97,7 @@ var AllChecks = []*analysis.Analyzer{
 	AT009.Analyzer,
 	AT010.Analyzer,
 	AT011.Analyzer,
+	AT012.Analyzer,
 	R001.Analyzer,
 	R002.Analyzer,
 	R003.Analyzer,


### PR DESCRIPTION
Closes #219