### PR TITLE
Ensure SchemaInfo.Schema.Default is non-nil if it is really set

### DIFF
--- a/helper/terraformtype/helper/schema/type_schema.go
+++ b/helper/terraformtype/helper/schema/type_schema.go
@@ -132,6 +132,7 @@ func NewSchemaInfo(cl *ast.CompositeLit, info *types.Info) *SchemaInfo {
 	}
 
 	if kvExpr := result.Fields[SchemaFieldDefault]; kvExpr != nil && astutils.ExprValue(kvExpr.Value) != nil {
+		result.Schema.Default = struct{}{}
 		switch result.Schema.Type {
 		case typeBool:
 			if ptr := astutils.ExprBoolValue(kvExpr.Value); ptr != nil {
@@ -145,8 +146,6 @@ func NewSchemaInfo(cl *ast.CompositeLit, info *types.Info) *SchemaInfo {
 			if ptr := astutils.ExprStringValue(kvExpr.Value); ptr != nil {
 				result.Schema.Default = *ptr
 			}
-		default:
-			result.Schema.Default = func() (interface{}, error) { return nil, nil }
 		}
 	}
 

--- a/passes/S004/testdata/src/a/main.go
+++ b/passes/S004/testdata/src/a/main.go
@@ -23,10 +23,16 @@ func f() {
 		Default: true,
 	}
 
-	_ = map[string]*schema.Schema{ 
+	_ = map[string]*schema.Schema{
 		"name": { // want "schema should not enable Required and configure Default"
 			Required: true,
 			Default:  true,
 		},
+	}
+
+	_ = schema.Schema{ // want "schema should not enable Required and configure Default"
+		Required: true,
+		Type:     schema.TypeString,
+		Default:  string("abc"),
 	}
 }


### PR DESCRIPTION
In prior implementation, if the schema type is one of int/bool/string,
the `.Schema.Default` might not be set if the `Default` is not set to a
BasicLiteral(for int/string) or a bool Ident (for bool). It is a very
popular case that the default value of a string property is set to an
expression that is to convert the type from another string aliased type.