### PR TITLE
passes/commentignore: Support multiple line comments

### DIFF
--- a/passes/AT001/testdata/src/a/comment_ignore.go
+++ b/passes/AT001/testdata/src/a/comment_ignore.go
@@ -20,4 +20,17 @@ func fcommentignore() {
 
 	//lintignore:AT001,AT002 // extra comment
 	_ = r.TestCase{}
+
+	// extra comment
+	//lintignore:AT001
+	_ = r.TestCase{}
+
+	// extra comment
+	//lintignore:AT001
+	// extra comment
+	_ = r.TestCase{}
+
+	//lintignore:AT001
+	// extra comment
+	_ = r.TestCase{}
 }

--- a/passes/commentignore/ignore.go
+++ b/passes/commentignore/ignore.go
@@ -40,19 +40,27 @@ func (ignorer *Ignorer) ShouldIgnore(key string, n ast.Node) bool {
 func run(pass *analysis.Pass) (interface{}, error) {
 	ignores := map[string][]ignore{}
 	for _, f := range pass.Files {
-		cmap := ast.NewCommentMap(pass.Fset, f, f.Comments)
-		for n, cgs := range cmap {
-			for _, cg := range cgs {
-				if strings.HasPrefix(cg.Text(), commentIgnorePrefix) {
-					commentIgnore := strings.TrimPrefix(cg.Text(), commentIgnorePrefix)
-					// Allow extra // comment after keys
-					commentIgnoreParts := strings.Split(commentIgnore, "//")
-					keys := strings.TrimSpace(commentIgnoreParts[0])
+		for n, commentGroups := range ast.NewCommentMap(pass.Fset, f, f.Comments) {
+			for _, commentGroup := range commentGroups {
+				for _, comment := range commentGroup.List {
+					if comment == nil {
+						continue
+					}
 
-					// Allow multiple comma separated ignores
-					for _, key := range strings.Split(keys, ",") {
-						// is it possible for nested pos/end to be outside the largest nodes?
-						ignores[key] = append(ignores[key], ignore{n.Pos(), n.End()})
+					// Remove // comment prefix
+					commentText := strings.TrimPrefix(comment.Text, "//")
+
+					if strings.HasPrefix(commentText, commentIgnorePrefix) {
+						commentIgnore := strings.TrimPrefix(commentText, commentIgnorePrefix)
+						// Allow extra // comment after keys
+						commentIgnoreParts := strings.Split(commentIgnore, "//")
+						keys := strings.TrimSpace(commentIgnoreParts[0])
+
+						// Allow multiple comma separated ignores
+						for _, key := range strings.Split(keys, ",") {
+							// is it possible for nested pos/end to be outside the largest nodes?
+							ignores[key] = append(ignores[key], ignore{n.Pos(), n.End()})
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Closes #248

Previously, multiple line comments including the lintignore directive would not take effect unless it was on the first line. Now any comment line can implement the lintignore directive.