### PR TITLE
commentignore: Allow leading space

### DIFF
--- a/passes/AT001/testdata/src/a/comment_ignore.go
+++ b/passes/AT001/testdata/src/a/comment_ignore.go
@@ -7,13 +7,23 @@ import (
 func fcommentignore() {
 	_ = r.TestCase{} //lintignore:AT001
 
+	_ = r.TestCase{} // lintignore:AT001
+
 	//lintignore:AT001
+	_ = r.TestCase{}
+
+	// lintignore:AT001
 	_ = r.TestCase{}
 
 	//lintignore:AT001,AT002
 	_ = r.TestCase{}
 
 	_ = r.TestCase{} //lintignore:AT001 // extra comment
+
+	_ = r.TestCase{} // lintignore:AT001 // extra comment
+
+	// lintignore:AT001 // extra comment
+	_ = r.TestCase{}
 
 	//lintignore:AT001 // extra comment
 	_ = r.TestCase{}
@@ -27,6 +37,11 @@ func fcommentignore() {
 
 	// extra comment
 	//lintignore:AT001
+	// extra comment
+	_ = r.TestCase{}
+
+	// extra comment
+	// lintignore:AT001
 	// extra comment
 	_ = r.TestCase{}
 

--- a/passes/commentignore/ignore.go
+++ b/passes/commentignore/ignore.go
@@ -48,7 +48,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					}
 
 					// Remove // comment prefix
-					commentText := strings.TrimPrefix(comment.Text, "//")
+					commentText := strings.TrimLeft(strings.TrimPrefix(comment.Text, "//"), " ")
 
 					if strings.HasPrefix(commentText, commentIgnorePrefix) {
 						commentIgnore := strings.TrimPrefix(commentText, commentIgnorePrefix)


### PR DESCRIPTION
fixes #251

This fixes a regression in v0.28.0 where leading spaces no longer work in the `// lintignore` comment. ❤️ 