### PR TITLE
docs: update in favor of homebrew-core one

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ docker pull bflad/tfproviderlint
 ### Homebrew Install
 
 ```console
-$ brew install bflad/tap/tfproviderlint
+$ brew install tfproviderlint
 ```
 
 ## Usage


### PR DESCRIPTION
I have helped creating the formula in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/88917), and it is pretty well maintained so far. I think we can update the docs to use a simpler way. Let me know if that makes sense.